### PR TITLE
link-discord fix: Fix link to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h3 align="center"> 🚧  The platform is still under development 🚧 </h3>
 
 ## Link to discord discussions
-<a href="https://nextjs.org/" target="_blank">
+<a href="https://discord.com/invite/XppcdxFv" target="_blank">
 https://discord.com/invite/XppcdxFv
 </a>
 


### PR DESCRIPTION
Corrigi o link do discord que estava abrindo o site do next.js!